### PR TITLE
Updated code for compatability with horizontal tables

### DIFF
--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -47,7 +47,7 @@ const {
 	// TODO: Use only margin bottom once :has() is widely supported
 
 	.prose {
-		max-width: 100%;
+		max-width: 70ch;
 
 		// select every text element
 		& :where(blockquote, dd, div, dl, dt, figcaption, figure, li, ol, p, pre, ul, hr, table) {
@@ -241,6 +241,8 @@ const {
 			width: 100%;
 			margin-top: var(--space-l);
 			margin-bottom: var(--space-l);
+			display: block;
+			overflow-x: auto;
 
 			@media (min-width: 1280px) {
 				margin-left: calc(-1 * var(--space-xs));
@@ -248,7 +250,7 @@ const {
 			}
 		}
 
-		& thead th {
+		& th {
 			--th-background: var(--purble-100);
 			@media (prefers-color-scheme: dark) {
 				--th-background: var(--purble-900);

--- a/src/pages/blog/example-post.mdx
+++ b/src/pages/blog/example-post.mdx
@@ -299,6 +299,123 @@ import Callout from '@components/Callout.astro';
 
 Anyways, I guess that's all we have at the moment. So, ciao for now, and see you next time we update this page!
 
+## Other
+
+### Vertical Table
+
+#### Basic
+
+```mdx
+<table>
+  <tr>
+    <th> Title </th>
+    <td> `name` </td>
+    <td> **bonus** </td>
+  </tr>
+  <tr>
+    <th> Entry </th>
+    <td> $$ data^2 $$ </td>
+    <td> *more* </td>
+  </tr>
+</table>
+```
+
+<table>
+  <tr>
+    <th> Title </th>
+    <td> `name` </td>
+    <td> **bonus** </td>
+  </tr>
+  <tr>
+    <th> Entry </th>
+    <td> $$ data^2 $$ </td>
+    <td> *more* </td>
+  </tr>
+</table>
+
+#### Scroll
+
+```mdx
+<table>
+  <tr>
+    <th> Long </th>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+  </tr>
+</table>
+```
+
+<table>
+  <tr>
+    <th> Long </th>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+    <td> Buffer </td>
+  </tr>
+</table>
+
+#### Complex
+
+```mdx
+<table>
+  <tr>
+      <td rowspan="2"> tall </td>
+      <th colspan="2"> King Table </th>
+  </tr>
+  <tr>
+      <th> Sub1 </th>
+      <th> Sub2 </th>
+  </tr>
+  <tr>
+      <th> Entry 1 </th>
+      <td> some data </td>
+      <td> $$ \frac{1}{\alpha} $$ </td>
+  </tr>
+</table>
+```
+
+<table>
+  <tr>
+      <td rowspan="2"> tall </td>
+      <th colspan="2"> King Table </th>
+  </tr>
+  <tr>
+      <th> Sub1 </th>
+      <th> Sub2 </th>
+  </tr>
+  <tr>
+      <th> Entry 1 </th>
+      <td> some data </td>
+      <td> $$ \frac{1}{\alpha} $$ </td>
+  </tr>
+</table>
 
 $$
 


### PR DESCRIPTION
This updates the example post to include horizontal tables, and updates the CSS to facilitate the following:
- `thead th` to `th`: horizontal tables cannot have multiple `theads`
- `.prose max-width`: explicitly sets the limit to avoid content extending beyond screen
- `overflow-x`: so that tables can be scrolled horizontally